### PR TITLE
Alloc fixed cells in a vertical-first fashion

### DIFF
--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -346,10 +346,14 @@ impl<'a, F: ScalarField> Context<'a, F> {
         {
             self.total_fixed += 1;
         }
-        self.fixed_col += 1;
-        if self.fixed_col == self.fixed_columns.len() {
-            self.fixed_col = 0;
-            self.fixed_offset += 1;
+        self.fixed_offset += 1;
+        if self.fixed_offset == self.max_rows {
+            self.fixed_col += 1;
+            self.fixed_offset = 0;
+
+            if self.fixed_col >= self.fixed_columns.len() {
+                panic!("NOT ENOUGH FIXED COLUMNS");
+            }
         }
         cell
     }


### PR DESCRIPTION
Previously, the fixed cells are assigned in a *horizontal-first* fashion, i.e. it would not use next row unless all fixed columns of current row have all been assigned. Note that this behavior is different from other type of columns.
- Advice cells are assigned in a **vertical-first** fashion. 
- Lookup advice cells are assigned in a **vertical-first** fashion in `copy_and_lookup_cells()` too.

Therefore, this PR aims to make the assignment of fixed cells to be consistent with others.