### PR TITLE
fixed mul -1 bug

### DIFF
--- a/halo2-ecc/src/bn254/final_exp.rs
+++ b/halo2-ecc/src/bn254/final_exp.rs
@@ -85,9 +85,12 @@ impl<F: PrimeField> Fp12Chip<F> {
             if z != 0 {
                 assert!(z == 1 || z == -1);
                 if is_started {
-                    res = if z == 1 { self.mul(ctx, &res, a) } else { 
-                        // todo: double check that 
-                        self.divide_unsafe(ctx, &res, a) };
+                    res = if z == 1 {
+                        self.mul(ctx, &res, a)
+                    } else {
+                        // todo: double check that
+                        self.divide_unsafe(ctx, &res, a)
+                    };
                 } else {
                     assert_eq!(z, 1);
                     is_started = true;
@@ -286,7 +289,11 @@ impl<F: PrimeField> Fp12Chip<F> {
                 assert!(z == 1 || z == -1);
                 if is_started {
                     let mut res = self.cyclotomic_decompress(ctx, compression);
-                    res = if z == 1 { self.mul(ctx, &res, &a) } else { self.divide_unsafe(ctx, &res, &a) };
+                    res = if z == 1 {
+                        self.mul(ctx, &res, &a)
+                    } else {
+                        self.divide_unsafe(ctx, &res, &a)
+                    };
                     // compression is free, so it doesn't hurt (except possibly witness generation runtime) to do it
                     // TODO: alternatively we go from small bits to large to avoid this compression
                     compression = self.cyclotomic_compress(&res);


### PR DESCRIPTION
- the fixed_multiply function panics when the scalar is `-1`. See https://github.com/zhenfeizhang/halo2-lib-ec-fix-mul/blob/51454c8b79ad27a1c0f3864614e1760d3b4d9230/src/lib.rs#L129
- this PR fixes the bug, but in the meantime, `fixed_multiply` also requires random point which may be vulnerable