### PR TITLE
halo2-ecc: update `is_on_curve` helper to support p256

### DIFF
--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -343,14 +343,15 @@ where
     // calculate x^3
     rhs = chip.mul_no_carry(ctx, &rhs, &P.x);
 
-    let a = FC::fe_to_constant(C::a());
+    let a_const = FC::fe_to_constant(C::a());
+    let a = chip.load_constant(ctx, a_const);
     let b = FC::fe_to_constant(C::b());
     // calculate x^3 + b
     rhs = chip.add_constant_no_carry(ctx, &rhs, b);
     // calculate `a*x` part of the whole equation: `y^2= x^3 + a*x + b`, if a = 0 (for secp256k1),
     // `a*x` is zero.
     // add chip.mul_constant helper ?
-    let ax = chip.mul(ctx, &P.x, a.into());
+    let ax = chip.mul(ctx, &P.x, &a);
     // calculate x^3 + a*x  + b
     rhs = chip.add_no_carry(ctx, &rhs, &ax);
 
@@ -627,13 +628,15 @@ impl<F: PrimeField, FC: FieldChip<F>> EccChip<F, FC> {
         let mut rhs = self.field_chip.mul(ctx, &P.x, &P.x);
         rhs = self.field_chip.mul_no_carry(ctx, &rhs, &P.x);
 
-        let a = FC::fe_to_constant(C::a());
+        let a_const = FC::fe_to_constant(C::a());
+        let a = self.field_chip.load_constant(ctx, a_const);
+
         let b = FC::fe_to_constant(C::b());
         rhs = self.field_chip.add_constant_no_carry(ctx, &rhs, b);
         // calculate `a*x` part of the whole equation: `y^2= x^3 + a*x + b`, if a = 0 (for secp256k1),
         // `a*x` is zero.
         // add chip.mul_constant helper ?
-        let ax = self.field_chip.mul(ctx, &P.x, a.into());
+        let ax = self.field_chip.mul(ctx, &P.x, &a);
         // calculate x^3 + a*x  + b
         rhs = self.field_chip.add_no_carry(ctx, &rhs, &ax);
         let mut diff = self.field_chip.sub_no_carry(ctx, &lhs, &rhs);

--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -633,9 +633,9 @@ impl<F: PrimeField, FC: FieldChip<F>> EccChip<F, FC> {
         // calculate `a*x` part of the whole equation: `y^2= x^3 + a*x + b`, if a = 0 (for secp256k1),
         // `a*x` is zero.
         // add chip.mul_constant helper ?
-        let ax = chip.mul(ctx, &P.x, a.into());
+        let ax = self.field_chip.mul(ctx, &P.x, a.into());
         // calculate x^3 + a*x  + b
-        rhs = chip.add_no_carry(ctx, &rhs, &ax);
+        rhs = self.field_chip.add_no_carry(ctx, &rhs, &ax);
         let mut diff = self.field_chip.sub_no_carry(ctx, &lhs, &rhs);
         diff = self.field_chip.carry_mod(ctx, &diff);
 


### PR DESCRIPTION
this PR fix issue #27 
for secp256r1 curve: y^2 = x^3 + ax + b, parameter `a` is not zero, can not omit it like secp256k1. here add `a*x` part to the circuit equation checking.
include two helpers:
   - [x]  is_on_curve
   - [x] is_on_curve_or_infinity

This change is compatible with secp256k1 .